### PR TITLE
Improve accelerator compiler support

### DIFF
--- a/.github/workflows/reusable_test_framework.yml
+++ b/.github/workflows/reusable_test_framework.yml
@@ -173,6 +173,7 @@ jobs:
           else
             source /root/scripts/use_${{inputs.compilo_name}}-${{inputs.compilo_version}}.sh
           fi
+          echo "USE_MOLD=true" >> $GITHUB_ENV
 
       - name: Set accelerator compiler
         if: "${{ inputs.acc_compilo_name != '' }}"
@@ -180,6 +181,7 @@ jobs:
         run: |
           if [[ "${{ inputs.acc_compilo_name }}" == "cuda" ]]; then
             echo "ACC_COMPILER=nvcc" >> $GITHUB_ENV
+            echo "USE_MOLD=true" >> $GITHUB_ENV
             if [[ "${{ inputs.acc_compilo_version }}" == "" ]]; then
               source /root/scripts/use_cuda.sh
             else
@@ -187,6 +189,7 @@ jobs:
             fi
           elif [[ "${{ inputs.acc_compilo_name }}" == "clang_cuda" ]]; then
             echo "ACC_COMPILER=clang_cuda" >> $GITHUB_ENV
+            echo "USE_MOLD=false" >> $GITHUB_ENV
             if [[ "${{ inputs.acc_compilo_version }}" == "" ]]; then
               source /root/scripts/use_clang_cuda.sh
             else
@@ -194,6 +197,7 @@ jobs:
             fi
           elif [[ "${{ inputs.acc_compilo_name }}" == "rocm" ]]; then
             echo "ACC_COMPILER=amdclang" >> $GITHUB_ENV
+            echo "USE_MOLD=false" >> $GITHUB_ENV
             echo "CMAKE_ADD_ARGS=${{ env.CMAKE_ADD_ARGS }} -DCMAKE_PREFIX_PATH=/opt/rocm" >> $GITHUB_ENV
             if [[ "${{ inputs.acc_compilo_version }}" == "" ]]; then
               source /root/scripts/use_rocm.sh
@@ -202,6 +206,7 @@ jobs:
             fi
           elif [[ "${{ inputs.acc_compilo_name }}" == "acpp" ]]; then
             echo "ACC_COMPILER=acpp" >> $GITHUB_ENV
+            echo "USE_MOLD=true" >> $GITHUB_ENV
           fi
 
       - name: Get date
@@ -276,6 +281,7 @@ jobs:
           cmake_additionnal_args: '${{ env.CMAKE_ADD_ARGS }} ${{ inputs.cmake_additionnal_args }} ${{ env.M_RAND }}'
           verbose: ${{ inputs.verbose }}
           type_build: ${{ inputs.type_build }}
+          use_mold: ${{ env.USE_MOLD }}
           compilo: ${{ inputs.compilo_name }}
           acc_compilo: ${{ env.ACC_COMPILER }}
           with_samples: ${{ inputs.with_samples }}

--- a/.github/workflows/reusable_test_framework.yml
+++ b/.github/workflows/reusable_test_framework.yml
@@ -23,16 +23,16 @@ on:
         type: string
         required: false
         default: 'OMPI'
-      cuda:
-        description: 'CUDA version (cuda-XXX or false)'
+      acc_compilo_name:
+        description: 'Accelerator compiler name (cuda, acpp, clang)'
         type: string
         required: false
-        default: 'false'
-      use_acpp:
-        description: 'Use AdaptiveCPP ?'
-        type: boolean
+        default: ''
+      acc_compilo_version:
+        description: 'Accelerator compiler version (125, 126, ...) or empty str'
+        type: string
         required: false
-        default: false
+        default: ''
       type_build:
         description: 'Type of build (Debug, Check, Release)'
         type: string
@@ -169,11 +169,19 @@ jobs:
             source /root/scripts/use_${{inputs.compilo_name}}-${{inputs.compilo_version}}.sh
           fi
 
-      - name: Set CUDA
-        if: "${{ inputs.cuda != 'false' }}"
+      - name: Set accelerator compiler
+        if: "${{ inputs.acc_compilo_name != '' }}"
         shell: bash
         run: |
-          source /root/scripts/use_${{inputs.cuda}}.sh
+          if [[ "${{ inputs.acc_compilo_name }}" == "cuda" ]]; then
+            if [[ "${{ inputs.acc_compilo_version }}" == "" ]]; then
+              source /root/scripts/use_cuda.sh
+            else
+              source /root/scripts/use_cuda-${{inputs.acc_compilo_version}}.sh
+            fi
+          elif [[ "${{ inputs.acc_compilo_name }}" == "clang" ]]; then
+            source /root/scripts/use_cuda.sh
+          fi
 
       - name: Get date
         shell: bash
@@ -247,8 +255,7 @@ jobs:
           verbose: ${{ inputs.verbose }}
           type_build: ${{ inputs.type_build }}
           compilo: ${{ inputs.compilo_name }}
-          with_cuda: ${{ inputs.cuda != 'false' }}
-          with_acpp: ${{ inputs.use_acpp }}
+          acc_compilo: ${{ inputs.acc_compilo_name }}
           with_samples: ${{ inputs.with_samples }}
 
       - name: Upload log artifact

--- a/.github/workflows/reusable_test_framework.yml
+++ b/.github/workflows/reusable_test_framework.yml
@@ -174,13 +174,17 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ inputs.acc_compilo_name }}" == "cuda" ]]; then
+            echo "ACC_COMPILER=nvcc" >> $GITHUB_ENV
             if [[ "${{ inputs.acc_compilo_version }}" == "" ]]; then
               source /root/scripts/use_cuda.sh
             else
               source /root/scripts/use_cuda-${{inputs.acc_compilo_version}}.sh
             fi
           elif [[ "${{ inputs.acc_compilo_name }}" == "clang" ]]; then
+            echo "ACC_COMPILER=clang" >> $GITHUB_ENV
             source /root/scripts/use_cuda.sh
+          elif [[ "${{ inputs.acc_compilo_name }}" == "acpp" ]]; then
+            echo "ACC_COMPILER=acpp" >> $GITHUB_ENV
           fi
 
       - name: Get date
@@ -241,8 +245,9 @@ jobs:
             echo "::endgroup::"
           fi
 
+      # TODO : Retirer le nom de la branche avant de merge !
       - name: Build and install framework
-        uses: arcaneframework/gh_actions/build_install_framework@v2.2.0
+        uses: arcaneframework/gh_actions/build_install_framework@dev/ah-improve-accelerator-compiler-support
         with:
           source_dir: ${{ env.SOURCE_DIR }}
           build_dir: ${{ env.BUILD_DIR }}
@@ -255,7 +260,7 @@ jobs:
           verbose: ${{ inputs.verbose }}
           type_build: ${{ inputs.type_build }}
           compilo: ${{ inputs.compilo_name }}
-          acc_compilo: ${{ inputs.acc_compilo_name }}
+          acc_compilo: ${{ env.ACC_COMPILER }}
           with_samples: ${{ inputs.with_samples }}
 
       - name: Upload log artifact

--- a/.github/workflows/reusable_test_framework.yml
+++ b/.github/workflows/reusable_test_framework.yml
@@ -267,9 +267,8 @@ jobs:
             echo "::endgroup::"
           fi
 
-      # TODO : Retirer le nom de la branche avant de merge !
       - name: Build and install framework
-        uses: arcaneframework/gh_actions/build_install_framework@dev/ah-improve-accelerator-compiler-support
+        uses: arcaneframework/gh_actions/build_install_framework@v3.0.0
         with:
           source_dir: ${{ env.SOURCE_DIR }}
           build_dir: ${{ env.BUILD_DIR }}

--- a/.github/workflows/reusable_test_framework.yml
+++ b/.github/workflows/reusable_test_framework.yml
@@ -24,7 +24,7 @@ on:
         required: false
         default: 'OMPI'
       acc_compilo_name:
-        description: 'Accelerator compiler name (cuda, acpp, clang)'
+        description: 'Accelerator compiler name (cuda, acpp, clang_cuda, rocm)'
         type: string
         required: false
         default: ''
@@ -185,9 +185,21 @@ jobs:
             else
               source /root/scripts/use_cuda-${{inputs.acc_compilo_version}}.sh
             fi
-          elif [[ "${{ inputs.acc_compilo_name }}" == "clang" ]]; then
-            echo "ACC_COMPILER=clang" >> $GITHUB_ENV
-            source /root/scripts/use_cuda.sh
+          elif [[ "${{ inputs.acc_compilo_name }}" == "clang_cuda" ]]; then
+            echo "ACC_COMPILER=clang_cuda" >> $GITHUB_ENV
+            if [[ "${{ inputs.acc_compilo_version }}" == "" ]]; then
+              source /root/scripts/use_clang_cuda.sh
+            else
+              source /root/scripts/use_clang-${{inputs.acc_compilo_version}}_cuda.sh
+            fi
+          elif [[ "${{ inputs.acc_compilo_name }}" == "rocm" ]]; then
+            echo "ACC_COMPILER=amdclang" >> $GITHUB_ENV
+            echo "CMAKE_ADD_ARGS=${{ env.CMAKE_ADD_ARGS }} -DCMAKE_PREFIX_PATH=/opt/rocm" >> $GITHUB_ENV
+            if [[ "${{ inputs.acc_compilo_version }}" == "" ]]; then
+              source /root/scripts/use_rocm.sh
+            else
+              source /root/scripts/use_rocm-${{inputs.acc_compilo_version}}.sh
+            fi
           elif [[ "${{ inputs.acc_compilo_name }}" == "acpp" ]]; then
             echo "ACC_COMPILER=acpp" >> $GITHUB_ENV
           fi

--- a/.github/workflows/reusable_test_framework.yml
+++ b/.github/workflows/reusable_test_framework.yml
@@ -95,6 +95,11 @@ on:
         type: string
         required: false
         default: 'aio'
+      artifact_key_prefix:
+        description: 'Artifact key prefix'
+        type: string
+        required: false
+        default: 'artifact'
 
 
 env:
@@ -267,7 +272,7 @@ jobs:
         if: ${{ failure() || inputs.ccache_debug_mode == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.cache_key_prefix }}-log_config_build-artifact
+          name: ${{ inputs.artifact_key_prefix }}-log_config_build-artifact
           path: ${{ env.LOG_DIR }}
           retention-days: 7
 
@@ -342,6 +347,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.cache_key_prefix }}-test-artifact
+          name: ${{ inputs.artifact_key_prefix }}-test-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ This composite action can work with any docker image with the necessary/recommen
 | `cmake_additionnal_args`  | Additional arguments given to CMake configure. Example: `'-DARCCORE_CXX_STANDARD=23 -DARCANE_DISABLE_PERFCOUNTER_TESTS=ON -DARCANE_DEFAULT_PARTITIONER=Metis'`  | No () |
 | `type_build`  | Type of build. You can choose `Debug`, `Check` or `Release`.  | No (`Release`) |
 | `use_ninja`  | Use ninja instead of make to build the Framework.  | No (`true`) |
+| `use_mold`  | Use mold linker instead of ld to build the Framework.  | No (`false`) |
 | `use_shared_libs`  | Generate shared libs instead of static libs.  | No (`true`) |
 | `verbose`  | Add verbose args for make/ninja.  | No (`false`) |
 | `compilo`  | Compiler to build the Framework. You can choose `gcc` or `clang`. If you want an other compiler, you can use `cmake_additionnal_args` input.  | No (`gcc`) |
-| `acc_compilo`  | Compiler to compile GPU part of the framework. You can choose `nvcc` (for CUDA `nvcc` compiler) or `clang` (to compile CUDA part with `clang++`) or `acpp` (to compile SYCL part with AdaptiveCPP).  | No () |
+| `acc_compilo`  | Compiler to compile GPU part of the framework. You can choose `nvcc` (for CUDA `nvcc` compiler) or `clang_cuda` (to compile CUDA part with `clang++`) or `acpp` (to compile SYCL part with AdaptiveCPP).  | No () |
 | `with_samples`  | Build samples. Need an `install_dir`. | No (`false`) |
 | `with_userdoc`  | Build the user documentation. Available in `build_dir/share/userdoc`. | No (`false`) |
 | `with_devdoc`  | Build the dev documentation. Available in `build_dir/share/devdoc`. | No (`false`) |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This composite action can work with any docker image with the necessary/recommen
 | `use_shared_libs`  | Generate shared libs instead of static libs.  | No (`true`) |
 | `verbose`  | Add verbose args for make/ninja.  | No (`false`) |
 | `compilo`  | Compiler to build the Framework. You can choose `gcc` or `clang`. If you want an other compiler, you can use `cmake_additionnal_args` input.  | No (`gcc`) |
-| `acc_compilo`  | Compiler to compile GPU part of the framework. You can choose `cuda` (for `nvcc` compiler) or `clang` (to compile CUDA part with `clang++`) or `acpp` (to use AdaptiveCPP).  | No () |
+| `acc_compilo`  | Compiler to compile GPU part of the framework. You can choose `nvcc` (for CUDA `nvcc` compiler) or `clang` (to compile CUDA part with `clang++`) or `acpp` (to compile SYCL part with AdaptiveCPP).  | No () |
 | `with_samples`  | Build samples. Need an `install_dir`. | No (`false`) |
 | `with_userdoc`  | Build the user documentation. Available in `build_dir/share/userdoc`. | No (`false`) |
 | `with_devdoc`  | Build the dev documentation. Available in `build_dir/share/devdoc`. | No (`false`) |
@@ -80,7 +80,7 @@ jobs:
           submodules: true
 
       - name: Build and install framework
-        uses: arcaneframework/gh_actions/build_install_framework@v2
+        uses: arcaneframework/gh_actions/build_install_framework@v3
         with:
           source_dir: ${{ env.SOURCE_DIR }}
           build_dir: ${{ env.BUILD_DIR }}
@@ -89,7 +89,7 @@ jobs:
           cmake_additionnal_args: '-DARCCORE_CXX_STANDARD=23 -DARCANE_DISABLE_PERFCOUNTER_TESTS=ON -DARCANE_DEFAULT_PARTITIONER=Metis'
           type_build: Debug
           compilo: gcc
-          with_cuda: false
+          acc_compilo: nvcc
           with_samples: false
 ```
 
@@ -101,7 +101,7 @@ Before using it, you can read this Github Docs page : https://docs.github.com/en
 
 There are several 'input' options. To find out the available options, you can read the YAML action file.
 
-This reusable action can work only with [framework-ci](https://github.com/arcaneframework/framework-ci) images. The reusable actions version 1 can work with all framework-ci images v1 and v2 (`20240703` or before). The reusable action version 2 need framework-ci images v3 (`20240717` and after).
+This reusable action can work only with [framework-ci](https://github.com/arcaneframework/framework-ci) images. The reusable actions version 1 can work with all framework-ci images v1 and v2 (`20240703` or before). The reusable action version 2 and later need framework-ci images v3 (`20240717` and after).
 
 
 ### Example
@@ -110,13 +110,12 @@ https://github.com/arcaneframework/framework/blob/main/.github/workflows/build_t
 jobs:
   build-install-test:
     name: '[U24_C18_M]_OMPI_Release'
-    uses: 'arcaneframework/gh_actions/.github/workflows/reusable_test_framework.yml@v2'
+    uses: 'arcaneframework/gh_actions/.github/workflows/reusable_test_framework.yml@v3'
     with:
       image: ghcr.io/arcaneframework/ubuntu-2404:clang-18_minimal_20240717
       compilo_name: clang
       compilo_version: 18
       mpi: OMPI
-      cuda: 'false'
       type_build: Release
       cmake_additionnal_args: '-DARCCORE_CXX_STANDARD=23 -DARCANE_DISABLE_PERFCOUNTER_TESTS=ON -DARCANE_DEFAULT_PARTITIONER=Metis'
       with_samples: true

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ This composite action can work with any docker image with the necessary/recommen
 | `use_shared_libs`  | Generate shared libs instead of static libs.  | No (`true`) |
 | `verbose`  | Add verbose args for make/ninja.  | No (`false`) |
 | `compilo`  | Compiler to build the Framework. You can choose `gcc` or `clang`. If you want an other compiler, you can use `cmake_additionnal_args` input.  | No (`gcc`) |
-| `with_cuda`  | Use CUDA to compile GPU part of the framework. Need `nvcc` compiler.  | No (`false`) |
-| `with_acpp`  | Use AdaptiveCPP to compile GPU part of the framework. Need `acpp` compiler.  | No (`false`) |
+| `acc_compilo`  | Compiler to compile GPU part of the framework. You can choose `cuda` (for `nvcc` compiler) or `clang` (to compile CUDA part with `clang++`) or `acpp` (to use AdaptiveCPP).  | No () |
 | `with_samples`  | Build samples. Need an `install_dir`. | No (`false`) |
 | `with_userdoc`  | Build the user documentation. Available in `build_dir/share/userdoc`. | No (`false`) |
 | `with_devdoc`  | Build the dev documentation. Available in `build_dir/share/devdoc`. | No (`false`) |

--- a/build_install_framework/action.yml
+++ b/build_install_framework/action.yml
@@ -65,16 +65,11 @@ inputs:
     type: string
     required: false
     default: "gcc"
-  with_cuda:
-    description: 'Compile with CUDA too ?'
-    type: boolean
+  acc_compilo:
+    description: 'Accelerator compiler (cuda, clang, acpp)'
+    type: string
     required: false
-    default: false
-  with_acpp:
-    description: 'Compile with AdaptiveCPP too ?'
-    type: boolean
-    required: false
-    default: false
+    default: ""
   with_samples:
     description: 'Compile samples too ? Require install_dir.'
     type: boolean
@@ -126,12 +121,10 @@ runs:
     - name: Personalize compiler
       shell: bash
       run: |
-        if [[ "${{ inputs.with_acpp }}" == "true" ]]; then
+        if [[ "${{ inputs.acc_compilo }}" == "acpp" ]]; then
           echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} \
           -DCMAKE_C_COMPILER=clang \
           -DCMAKE_CXX_COMPILER=acpp \
-          -DARCANE_ACCELERATOR_MODE=SYCLDPCPP \
-          -DCMAKE_SYCL_COMPILER=acpp \
           " >> $GITHUB_ENV
         elif [[ "${{ inputs.compilo }}" == "clang" ]]; then
           echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} \
@@ -145,12 +138,28 @@ runs:
           " >> $GITHUB_ENV
         fi
 
-    # Oui, ici, le type 'boolean' ne semble pas l'interesser plus que ça...
-    - name: Add cuda
-      if: "${{ inputs.with_cuda == 'true' }}"
+    - name: Personalize accelerator compiler
+      if: "${{ inputs.acc_compilo != '' }}"
       shell: bash
       run: |
-        echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} -DARCANE_ACCELERATOR_MODE=CUDANVCC -DCMAKE_CUDA_COMPILER=nvcc" >> $GITHUB_ENV
+      if [[ "${{ inputs.acc_compilo }}" == "acpp" ]]; then
+          echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} \
+          -DARCANE_ACCELERATOR_MODE=SYCLDPCPP \
+          -DCMAKE_SYCL_COMPILER=acpp \
+          " >> $GITHUB_ENV
+        elif [[ "${{ inputs.acc_compilo }}" == "cuda" ]]; then
+          echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} \
+          -DARCANE_ACCELERATOR_MODE=CUDANVCC \
+          -DCMAKE_CUDA_COMPILER=nvcc \
+          " >> $GITHUB_ENV
+        elif [[ "${{ inputs.acc_compilo }}" == "clang" ]]; then
+          echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} \
+          -DARCANE_ACCELERATOR_MODE=CUDANVCC \
+          -DCMAKE_CUDA_COMPILER=clang++ \
+          " >> $GITHUB_ENV
+        else
+          exit 1
+        fi
 
     - name: Add install prefix
       if: "${{ inputs.install_dir != '' }}"
@@ -158,6 +167,7 @@ runs:
       run: |
         echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} -DCMAKE_INSTALL_PREFIX=${{ inputs.install_dir }}" >> $GITHUB_ENV
 
+    # Oui, ici, le type 'boolean' ne semble pas l'interesser plus que ça...
     - name: Use ninja
       if: "${{ inputs.use_ninja == 'true' }}"
       shell: bash

--- a/build_install_framework/action.yml
+++ b/build_install_framework/action.yml
@@ -66,7 +66,7 @@ inputs:
     required: false
     default: "gcc"
   acc_compilo:
-    description: 'Accelerator compiler (cuda, clang, acpp)'
+    description: 'Accelerator compiler (nvcc, clang, acpp)'
     type: string
     required: false
     default: ""
@@ -144,17 +144,17 @@ runs:
       run: |
       if [[ "${{ inputs.acc_compilo }}" == "acpp" ]]; then
           echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} \
-          -DARCANE_ACCELERATOR_MODE=SYCLDPCPP \
+          -DARCANE_ACCELERATOR_MODE=SYCL \
           -DCMAKE_SYCL_COMPILER=acpp \
           " >> $GITHUB_ENV
-        elif [[ "${{ inputs.acc_compilo }}" == "cuda" ]]; then
+        elif [[ "${{ inputs.acc_compilo }}" == "nvcc" ]]; then
           echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} \
-          -DARCANE_ACCELERATOR_MODE=CUDANVCC \
+          -DARCANE_ACCELERATOR_MODE=CUDA \
           -DCMAKE_CUDA_COMPILER=nvcc \
           " >> $GITHUB_ENV
         elif [[ "${{ inputs.acc_compilo }}" == "clang" ]]; then
           echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} \
-          -DARCANE_ACCELERATOR_MODE=CUDANVCC \
+          -DARCANE_ACCELERATOR_MODE=CUDA \
           -DCMAKE_CUDA_COMPILER=clang++ \
           " >> $GITHUB_ENV
         else

--- a/build_install_framework/action.yml
+++ b/build_install_framework/action.yml
@@ -142,7 +142,7 @@ runs:
       if: "${{ inputs.acc_compilo != '' }}"
       shell: bash
       run: |
-      if [[ "${{ inputs.acc_compilo }}" == "acpp" ]]; then
+        if [[ "${{ inputs.acc_compilo }}" == "acpp" ]]; then
           echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} \
           -DARCANE_ACCELERATOR_MODE=SYCL \
           -DCMAKE_SYCL_COMPILER=acpp \

--- a/build_install_framework/action.yml
+++ b/build_install_framework/action.yml
@@ -136,7 +136,7 @@ runs:
           -DCMAKE_C_COMPILER=clang \
           -DCMAKE_CXX_COMPILER=clang++ \
           " >> $GITHUB_ENV
-        else
+        elif [[ "${{ inputs.compilo }}" == "gcc" ]]; then
           echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} \
           -DCMAKE_C_COMPILER=gcc \
           -DCMAKE_CXX_COMPILER=g++ \

--- a/build_install_framework/action.yml
+++ b/build_install_framework/action.yml
@@ -50,6 +50,11 @@ inputs:
     type: boolean
     required: false
     default: true
+  use_mold:
+    description: 'Use mold linker instead of ld'
+    type: boolean
+    required: false
+    default: false
   use_shared_libs:
     description: 'Use shared libs instead of static libs'
     type: boolean
@@ -66,7 +71,7 @@ inputs:
     required: false
     default: "gcc"
   acc_compilo:
-    description: 'Accelerator compiler (nvcc, clang, acpp)'
+    description: 'Accelerator compiler (nvcc, clang_cuda, acpp, amdclang)'
     type: string
     required: false
     default: ""
@@ -152,10 +157,15 @@ runs:
           -DARCANE_ACCELERATOR_MODE=CUDA \
           -DCMAKE_CUDA_COMPILER=nvcc \
           " >> $GITHUB_ENV
-        elif [[ "${{ inputs.acc_compilo }}" == "clang" ]]; then
+        elif [[ "${{ inputs.acc_compilo }}" == "clang_cuda" ]]; then
           echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} \
           -DARCANE_ACCELERATOR_MODE=CUDA \
-          -DCMAKE_CUDA_COMPILER=clang++ \
+          -DCMAKE_CUDA_COMPILER=clang++_cuda \
+          " >> $GITHUB_ENV
+        elif [[ "${{ inputs.acc_compilo }}" == "amdclang" ]]; then
+          echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} \
+          -DARCANE_ACCELERATOR_MODE=ROCM \
+          -DCMAKE_CUDA_COMPILER=amdclang++ \
           " >> $GITHUB_ENV
         else
           exit 1
@@ -173,6 +183,12 @@ runs:
       shell: bash
       run: |
         echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} -GNinja" >> $GITHUB_ENV
+
+    - name: Use mold
+      if: "${{ inputs.use_mold == 'true' }}"
+      shell: bash
+      run: |
+        echo "ACTION_CMAKE_ADD_ARGS=${{ env.ACTION_CMAKE_ADD_ARGS }} -DCMAKE_LINKER_TYPE=MOLD" >> $GITHUB_ENV
 
     - name: Use shared libs
       if: "${{ inputs.use_shared_libs == 'true' }}"


### PR DESCRIPTION
Add two generic variables (`acc_compilo_name` and `acc_compilo_version`) to define a compiler for the accelerator part.
Add the support for Mold too.